### PR TITLE
Use unified mode in diff command

### DIFF
--- a/run.sh
+++ b/run.sh
@@ -5,7 +5,7 @@ QML_FILES=$(find . -name "$1")
 
 for f in $QML_FILES
 do
-  diff $f <(/opt/Qt/6.4.0/macos/bin/qmlformat $f)
+  diff -u $f <(/opt/Qt/6.4.0/macos/bin/qmlformat $f)
   EXIT_CODE=$(($EXIT_CODE || $?))
 done
 


### PR DESCRIPTION
This makes checking the required changes easier.

Previously I had one line failing, without any reference to that file.

```
161d160
< 
```

Currently, the output looks like:

```
--- ./src/qml/components/xyz.qml  2023-07-30 16:46:05.346656509 +0000
+++ /dev/fd/63  2023-07-30 16:46:05.842665448 +0000
@@ -158,7 +158,6 @@
                     radius: 8
                 }
                 // Sets the font size to a small value
-
             }
         }
```